### PR TITLE
temporarily disable sticky state

### DIFF
--- a/src/state/useInstrumentsState/index.ts
+++ b/src/state/useInstrumentsState/index.ts
@@ -1,5 +1,6 @@
-import useStickyState from '../../lib/useStickyState';
-import defaultInstrument from './defaultInstrument';
+import * as React from "react";
+import useStickyState from "../../lib/useStickyState";
+import defaultInstrument from "./defaultInstrument";
 
 // The point of this file is to allow other files a simple way to grab
 // the data held locally for the instruments state.
@@ -63,8 +64,11 @@ export type Instruments = Instrument[];
 // For now, I'm leaving the return value type as any[], which just means "an array of items of any types"
 // we'll come back to this and be more specific and well defined. 
 // The more defined we make the system the smoother it'll run.
-export default function( defaultValue: Instruments = DEFAULT_VALUE ): any[] {
-    return useStickyState( defaultValue, INSTRUMENTS_STICKY_KEY );
+export default function (defaultValue: Instruments = DEFAULT_VALUE): any[] {
+    return React.useState( defaultValue );
+    // TODO: Consider a better way than below to allow for state to be saved locally
+    // as a back up, and eventually to a db per user.
+//   return useStickyState(defaultValue, INSTRUMENTS_STICKY_KEY);
 }
 
 // A note on file names and the differences between jsx (& tsx) and js (& ts): 


### PR DESCRIPTION
This PR just removes the use of the "sticky state" pattern where we save some state to the machine via the browser.
The benefit of having the pattern is so that we can close the window and reopen it without either having to start the app state from defaults or "hydrate" the app with data requested (and thus waited for) user data.
The problem is, in development it can be a pain, as old state sticks around from whatever we changed last, the shape of the data (as in, what attributes/properties it has) might change over time and having to manually reset local state each time can be a pain (read [this stack over flow question](https://stackoverflow.com/a/7667975/3141007) for some tips about clearing local storage, good to know you can easily).
Let's look at a more robust version of this further down the line!

#### Testing

There shouldn't be any changes to how the app appears or anything here, but just make sure we see something rendering as a handpan... in that case the state change is working fine, from now on it'll just take the state from runtime memory rather than `localStorage`.